### PR TITLE
Reduce the pollution of global scope

### DIFF
--- a/lib/sizzle-bundle.js
+++ b/lib/sizzle-bundle.js
@@ -1,3 +1,4 @@
+
 var document = {
 	createElement: function(tag) {
 		return {
@@ -11,8 +12,13 @@ var document = {
 	nodeType: 9,
 	documentElement: { nodeName: 'HTML' }
 };
-global.document = document;
 document.ownerDocument = document;
-var window = { document: document }
+var window = { document: document };
 
-var _ = CONTENT;
+if (!global.document) {
+	global.document = document;
+}
+
+var _ = (function() {
+	CONTENT;
+})(window);


### PR DESCRIPTION
Don't overwrite `document` with the fake if one is already available.

Prevent Sizzle to depend on window