### PR TITLE
Fix looping over string in findBy function

### DIFF
--- a/dist/react-unit.js
+++ b/dist/react-unit.js
@@ -59,7 +59,7 @@ var Component = (function () {
       var ret = [];
       if (fn(this)) ret.push(this);
       var children = this.prop('children');
-      if (!children) return ret;
+      if (!children || isText(typeof children)) return ret;
       if (children.length === undefined) children = [children];
 
       return R.compose(R.concat(ret), R.filter(R.identity), R.flatten, R.map(function (c) {

--- a/dist/react-unit.js
+++ b/dist/react-unit.js
@@ -63,7 +63,7 @@ var Component = (function () {
       if (children.length === undefined) children = [children];
 
       return R.compose(R.concat(ret), R.filter(R.identity), R.flatten, R.map(function (c) {
-        return c.findBy(fn);
+        return c.findBy && c.findBy(fn);
       }))(children);
     }
   }, {

--- a/src/react-unit.jsx
+++ b/src/react-unit.jsx
@@ -39,7 +39,7 @@ class Component {
     var ret = [];
     if (fn(this)) ret.push(this);
     var children = this.prop('children');
-    if (!children) return ret;
+    if (!children || isText(typeof children)) return ret;
     if (children.length === undefined) children = [ children ];
 
     return R.compose(

--- a/src/react-unit.jsx
+++ b/src/react-unit.jsx
@@ -46,7 +46,7 @@ class Component {
       R.concat(ret),
       R.filter(R.identity),
       R.flatten,
-      R.map(c => c.findBy(fn))
+      R.map(c => c.findBy && c.findBy(fn))
     )(children);
   }
   findByTag(type) {
@@ -116,7 +116,7 @@ var mapChildren = (mapFn, comp) => {
     children: children,
     texts: texts
   };
-}
+};
 
 var mapComponent = R.curry((compCtor, parent, comp) => {
   if (typeof comp.type === 'function') return compCtor(parent, comp);

--- a/test/create-component-shallow.jsx
+++ b/test/create-component-shallow.jsx
@@ -50,7 +50,7 @@ describe('createComponent.shallow', () => {
     expect(lisaByTagAndOrder.prop('name')).toEqual('Lisa');
     expect(lisaByCompAndOrder.prop('name')).toEqual('Lisa');
   });
-    
+
   it('should find direct descendent components', () => {
     var component = createComponent.shallow(<Master/>);
 
@@ -81,6 +81,21 @@ describe('createComponent.shallow', () => {
     var child = component.findByQuery('div > Child')[0];
 
     expect(child).not.toBeUndefined();
+  });
+
+  it('should find findByComponent component rendering just a string a children', () => {
+    var Content = React.createClass({
+      render: function() { return <div>{this.props.children}</div> }
+    });
+
+    var Page = React.createClass({
+      render: function() { return (
+          <Content>Test</Content>
+      )}
+    });
+
+    var component = createComponent.shallow(<Page/>);
+    expect(component.findByComponent(Content).length).toEqual(1);
   });
 
   it('should allow findByQuery in component props', () => {

--- a/test/create-component-shallow.jsx
+++ b/test/create-component-shallow.jsx
@@ -83,7 +83,7 @@ describe('createComponent.shallow', () => {
     expect(child).not.toBeUndefined();
   });
 
-  it('should find findByComponent component rendering just a string a children', () => {
+  it('should find component rendering just a string as children', () => {
     var Content = React.createClass({
       render: function() { return <div>{this.props.children}</div> }
     });
@@ -95,6 +95,21 @@ describe('createComponent.shallow', () => {
     });
 
     var component = createComponent.shallow(<Page/>);
+    expect(component.findByComponent(Content).length).toEqual(1);
+  });
+  
+  it('should find component passing the children down to child component', () => {
+    var Content = React.createClass({
+      render: function() { return <div>{this.props.children}</div> }
+    });
+
+    var Page = React.createClass({
+      render: function() { return (
+          <Content>{this.props.children}</Content>
+      )}
+    });
+
+    var component = createComponent.shallow(<Page><div>Here</div></Page>);
     expect(component.findByComponent(Content).length).toEqual(1);
   });
 


### PR DESCRIPTION
Strings are not cleaned up in mapComponent function for shallow rendering and strings have method length which was causing it to crash with following error message

```
Failures:
1) createComponent.shallow should find findByComponent component rendering its children
1.1) TypeError: c.findBy is not a function
    TypeError: c.findBy is not a function
        at /Users/kamil/Workspace/react-unit/dist/react-unit.js:66:18
        at _map (/Users/kamil/Workspace/react-unit/node_modules/ramda/dist/ramda.js:376:27)
        at /Users/kamil/Workspace/react-unit/node_modules/ramda/dist/ramda.js:3919:23
        at /Users/kamil/Workspace/react-unit/node_modules/ramda/dist/ramda.js:178:28
        at f1 (/Users/kamil/Workspace/react-unit/node_modules/ramda/dist/ramda.js:156:27)
        at /Users/kamil/Workspace/react-unit/node_modules/ramda/dist/ramda.js:384:35
        at /Users/kamil/Workspace/react-unit/node_modules/ramda/dist/ramda.js:384:35
        at /Users/kamil/Workspace/react-unit/node_modules/ramda/dist/ramda.js:384:35
        at f1 (/Users/kamil/Workspace/react-unit/node_modules/ramda/dist/ramda.js:156:27)
        at Component.findBy (/Users/kamil/Workspace/react-unit/dist/react-unit.js:67:10)
```