### PR TITLE
fix shallow & interleaved rendering for ES6 components

### DIFF
--- a/src/react-unit.jsx
+++ b/src/react-unit.jsx
@@ -251,7 +251,7 @@ const createComponentShallow = R.curry(
   (createComponent, parent, ctor) => createComponent(
     (parent, ctor) => {
       const comp = new Component({
-        type: ctor.type.displayName,
+        type: ctor.type.displayName || ctor.type.name,
         _store: ctor._store,
         props: ctor.props
       }, parent);
@@ -280,7 +280,7 @@ const createComponentInterleaved = R.curry(
       const props = R.mergeAll([store.props, ctor.props, {}]);
 
       const comp = new Component({
-        type: ctor.type.displayName,
+        type: ctor.type.displayName || ctor.type.name,
         _store: R.merge(store, { props: props })
       }, parent);
       comp.componentInstance = ctor;


### PR DESCRIPTION
I didnt add any tests since the project does not use ES6 and doesnt have any transpiling already set up, but this works in our ES6 project, and it is very low risk because if the component doesnt have a displayName, the rendering is broken anyway.

#18 