### PR TITLE
Handle scenario where a component doesn't render anything

### DIFF
--- a/dist/react-unit.js
+++ b/dist/react-unit.js
@@ -231,6 +231,7 @@ var renderElement = function renderElement(mapper, reactElement) {
   var create = function create(reactElement) {
     shallowRenderer.render(reactElement);
     var reactComponent = shallowRenderer.getRenderOutput();
+    if (reactComponent == null) return null;
     var unitComponent = mapper(reactComponent);
     unitComponent.originalComponentInstance = reactElement;
     unitComponent.renderNew = function (newElement) {

--- a/src/react-unit.jsx
+++ b/src/react-unit.jsx
@@ -147,6 +147,7 @@ const renderElement = (mapper, reactElement) => {
   const create = reactElement => {
     shallowRenderer.render(reactElement);
     const reactComponent = shallowRenderer.getRenderOutput();
+    if (reactComponent == null) return null;
     const unitComponent = mapper(reactComponent);
     unitComponent.originalComponentInstance = reactElement;
     unitComponent.renderNew = newElement => create(newElement||reactElement);

--- a/test/create-component.jsx
+++ b/test/create-component.jsx
@@ -24,6 +24,10 @@ var Person = React.createClass({
   }
 });
 
+var NullRender = React.createClass({
+  render: function() { return null; }
+});
+
 describe('createComponent', () => {
   it('renders recursively, erasing components', () => {
     var component = createComponent(
@@ -41,6 +45,12 @@ describe('createComponent', () => {
 
     expect(persons.length).toEqual(0);
 
+  });
+
+  it('should work with a component that renders nothing', () => {
+    var component = createComponent(<NullRender/>);
+
+    expect(component).toEqual(null);
   });
 
   it('should work with null children', () => {


### PR DESCRIPTION
It's possible for a render function to return null, in which case
shallowRenderer.getRenderOutput() will return null as well.  This pull
request handles that scenario by returning null as well.

An example of a component that doesn't render anything: https://github.com/oliviertassinari/react-event-listener/blob/master/src/index.js#L121